### PR TITLE
修复保存带html后缀路径的问题

### DIFF
--- a/src/main/java/cc/ryanc/halo/web/controller/admin/AdminController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/admin/AdminController.java
@@ -182,7 +182,7 @@ public class AdminController extends BaseController {
                        @RequestParam(value = "page", defaultValue = "0") Integer page,
                        @RequestParam(value = "size", defaultValue = "10") Integer size) {
         Sort sort = new Sort(Sort.Direction.DESC, "logId");
-        Pageable pageable = new PageRequest(page, size, sort);
+        Pageable pageable = PageRequest.of(page, size, sort);
         Page<Logs> logs = logsService.findAllLogs(pageable);
         model.addAttribute("logs", logs);
         return "admin/widget/_logs-all";

--- a/src/main/java/cc/ryanc/halo/web/controller/admin/AttachmentController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/admin/AttachmentController.java
@@ -65,7 +65,7 @@ public class AttachmentController {
                               @RequestParam(value = "page", defaultValue = "0") Integer page,
                               @RequestParam(value = "size", defaultValue = "18") Integer size) {
         Sort sort = new Sort(Sort.Direction.DESC, "attachId");
-        Pageable pageable = new PageRequest(page, size, sort);
+        Pageable pageable = PageRequest.of(page, size, sort);
         Page<Attachment> attachments = attachmentService.findAllAttachments(pageable);
         model.addAttribute("attachments", attachments);
 
@@ -84,7 +84,7 @@ public class AttachmentController {
                                    @RequestParam(value = "page", defaultValue = "0") Integer page,
                                    @RequestParam(value = "id") String id) {
         Sort sort = new Sort(Sort.Direction.DESC, "attachId");
-        Pageable pageable = new PageRequest(page, 18, sort);
+        Pageable pageable = PageRequest.of(page, 18, sort);
         Page<Attachment> attachments = attachmentService.findAllAttachments(pageable);
         model.addAttribute("attachments", attachments);
         model.addAttribute("id", id);

--- a/src/main/java/cc/ryanc/halo/web/controller/admin/CommentController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/admin/CommentController.java
@@ -71,7 +71,7 @@ public class CommentController extends BaseController{
                            @RequestParam(value = "page",defaultValue = "0") Integer page,
                            @RequestParam(value = "size",defaultValue = "10") Integer size){
         Sort sort = new Sort(Sort.Direction.DESC,"commentDate");
-        Pageable pageable = new PageRequest(page,size,sort);
+        Pageable pageable = PageRequest.of(page,size,sort);
         Page<Comment> comments = commentService.findAllComments(status,pageable);
         model.addAttribute("comments",comments);
         model.addAttribute("publicCount",commentService.findAllComments(0,pageable).getTotalElements());

--- a/src/main/java/cc/ryanc/halo/web/controller/admin/PageController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/admin/PageController.java
@@ -142,7 +142,7 @@ public class PageController {
                           @RequestParam(value = "page", defaultValue = "0") Integer page,
                           @RequestParam(value = "size", defaultValue = "18") Integer size) {
         Sort sort = new Sort(Sort.Direction.DESC, "galleryId");
-        Pageable pageable = new PageRequest(page, size, sort);
+        Pageable pageable = PageRequest.of(page, size, sort);
         Page<Gallery> galleries = galleryService.findAllGalleries(pageable);
         model.addAttribute("galleries", galleries);
         return "admin/admin_page_gallery";

--- a/src/main/java/cc/ryanc/halo/web/controller/admin/PostController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/admin/PostController.java
@@ -176,12 +176,24 @@ public class PostController extends BaseController{
                 List<Tag> tags = tagService.strListToTagList(StringUtils.trim(tagList));
                 post.setTags(tags);
             }
+            post.setPostUrl(urlFilter(post.getPostUrl()));
             postService.saveByPost(post);
             logsService.saveByLogs(new Logs(LogsRecord.PUSH_POST,post.getPostTitle(),HaloUtil.getIpAddr(request),HaloUtil.getDate()));
         }catch (Exception e){
             log.error("未知错误：{0}",e.getMessage());
         }
     }
+
+    private static String urlFilter(String url) {
+        if (null != url) {
+            final boolean urlEndsWithHtmlPostFix = url.endsWith(".html") || url.endsWith(".htm");
+            if (urlEndsWithHtmlPostFix) {
+                return url.substring(0, url.lastIndexOf("."));
+            }
+        }
+        return url;
+    }
+
 
     /**
      * 处理移至回收站的请求
@@ -282,6 +294,7 @@ public class PostController extends BaseController{
     @GetMapping(value = "/checkUrl")
     @ResponseBody
     public boolean checkUrlExists(@PathParam("postUrl") String postUrl){
+        postUrl = urlFilter(postUrl);
         Post post = postService.findByPostUrl(postUrl,HaloConst.POST_TYPE_POST);
         return null!=post;
     }

--- a/src/main/java/cc/ryanc/halo/web/controller/admin/PostController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/admin/PostController.java
@@ -66,7 +66,7 @@ public class PostController extends BaseController{
                         @RequestParam(value = "page",defaultValue = "0") Integer page,
                         @RequestParam(value = "size",defaultValue = "10") Integer size){
         Sort sort = new Sort(Sort.Direction.DESC,"postDate");
-        Pageable pageable = new PageRequest(page,size,sort);
+        Pageable pageable = PageRequest.of(page,size,sort);
         Page<Post> posts = postService.findPostByStatus(status,HaloConst.POST_TYPE_POST,pageable);
         model.addAttribute("posts",posts);
         model.addAttribute("publishCount",postService.findPostByStatus(0,HaloConst.POST_TYPE_POST,pageable).getTotalElements());
@@ -93,7 +93,7 @@ public class PostController extends BaseController{
         try {
             //排序规则
             Sort sort = new Sort(Sort.Direction.DESC,"postId");
-            Pageable pageable = new PageRequest(page,size,sort);
+            Pageable pageable = PageRequest.of(page,size,sort);
             model.addAttribute("posts",postService.searchPosts(keyword,pageable));
         }catch (Exception e){
             log.error("未知错误：{0}",e.getMessage());

--- a/src/main/java/cc/ryanc/halo/web/controller/front/ArchivesController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/front/ArchivesController.java
@@ -61,7 +61,7 @@ public class ArchivesController extends BaseController {
 
         //所有文章数据，分页，material主题适用
         Sort sort = new Sort(Sort.Direction.DESC, "postDate");
-        Pageable pageable = new PageRequest(page - 1, 5, sort);
+        Pageable pageable = PageRequest.of(page - 1, 5, sort);
         Page<Post> posts = postService.findPostByStatus(0, HaloConst.POST_TYPE_POST, pageable);
         model.addAttribute("posts", posts);
         return this.render("archives");
@@ -109,7 +109,7 @@ public class ArchivesController extends BaseController {
             model.addAttribute("afterPost", afterPosts.get(afterPosts.size() - 1));
         }
         Sort sort = new Sort(Sort.Direction.DESC,"commentDate");
-        Pageable pageable = new PageRequest(0,999,sort);
+        Pageable pageable = PageRequest.of(0,999,sort);
         Page<Comment> comments = commentService.findCommentsByPostAndCommentStatus(post,pageable,2);
 
         model.addAttribute("post", post);

--- a/src/main/java/cc/ryanc/halo/web/controller/front/CategoriesController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/front/CategoriesController.java
@@ -71,7 +71,7 @@ public class CategoriesController extends BaseController {
         if(!StringUtils.isBlank(HaloConst.OPTIONS.get("index_posts"))){
             size = Integer.parseInt(HaloConst.OPTIONS.get("index_posts"));
         }
-        Pageable pageable = new PageRequest(page-1,size,sort);
+        Pageable pageable = PageRequest.of(page-1,size,sort);
         Page<Post> posts = postService.findPostByCategories(category,pageable);
         model.addAttribute("posts",posts);
         model.addAttribute("category",category);

--- a/src/main/java/cc/ryanc/halo/web/controller/front/CommentsController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/front/CommentsController.java
@@ -53,7 +53,7 @@ public class CommentsController {
     public List<Comment> getComment(@PathVariable Long postId) {
         Optional<Post> post = postService.findByPostId(postId);
         Sort sort = new Sort(Sort.Direction.DESC, "commentDate");
-        Pageable pageable = new PageRequest(0, 10, sort);
+        Pageable pageable = PageRequest.of(0, 10, sort);
         List<Comment> comments = commentService.findCommentsByPostAndCommentStatus(post.get(), pageable, 2).getContent();
         if (null == comments) {
             return null;

--- a/src/main/java/cc/ryanc/halo/web/controller/front/IndexController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/front/IndexController.java
@@ -66,7 +66,7 @@ public class IndexController extends BaseController {
             size = Integer.parseInt(HaloConst.OPTIONS.get("index_posts"));
         }
         //所有文章数据，分页
-        Pageable pageable = new PageRequest(page - 1, size, sort);
+        Pageable pageable = PageRequest.of(page - 1, size, sort);
         Page<Post> posts = postService.findPostByStatus(0, HaloConst.POST_TYPE_POST, pageable);
         model.addAttribute("posts", posts);
         return this.render("index");
@@ -90,7 +90,7 @@ public class IndexController extends BaseController {
         }
 
         //文章数据，只获取文章，没有分页
-        Pageable pageable = new PageRequest(page - 1, size, sort);
+        Pageable pageable = PageRequest.of(page - 1, size, sort);
         List<Post> posts = postService.findPostByStatus(0, HaloConst.POST_TYPE_POST, pageable).getContent();
         return posts;
     }

--- a/src/main/java/cc/ryanc/halo/web/controller/front/OthersController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/front/OthersController.java
@@ -40,7 +40,7 @@ public class OthersController {
         }
         //获取文章列表并根据时间排序
         Sort sort = new Sort(Sort.Direction.DESC, "postDate");
-        Pageable pageable = new PageRequest(0, Integer.parseInt(rssPosts), sort);
+        Pageable pageable = PageRequest.of(0, Integer.parseInt(rssPosts), sort);
         Page<Post> postsPage = postService.findPostByStatus(0, HaloConst.POST_TYPE_POST, pageable);
         List<Post> posts = postsPage.getContent();
         return postService.buildRss(posts);
@@ -56,7 +56,7 @@ public class OthersController {
     public String siteMap() {
         //获取文章列表并根据时间排序
         Sort sort = new Sort(Sort.Direction.DESC, "postDate");
-        Pageable pageable = new PageRequest(0, 999, sort);
+        Pageable pageable = PageRequest.of(0, 999, sort);
         Page<Post> postsPage = postService.findPostByStatus(0, HaloConst.POST_TYPE_POST, pageable);
         List<Post> posts = postsPage.getContent();
         return postService.buildSiteMap(posts);

--- a/src/main/java/cc/ryanc/halo/web/controller/front/PagesController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/front/PagesController.java
@@ -80,7 +80,7 @@ public class PagesController extends BaseController {
         Post post = postService.findByPostUrl(postUrl, HaloConst.POST_TYPE_PAGE);
 
         Sort sort = new Sort(Sort.Direction.DESC,"commentDate");
-        Pageable pageable = new PageRequest(0,999,sort);
+        Pageable pageable = PageRequest.of(0,999,sort);
         Page<Comment> comments = commentService.findCommentsByPostAndCommentStatus(post,pageable,2);
 
         model.addAttribute("comments",comments);

--- a/src/main/java/cc/ryanc/halo/web/controller/front/TagsController.java
+++ b/src/main/java/cc/ryanc/halo/web/controller/front/TagsController.java
@@ -80,7 +80,7 @@ public class  TagsController extends BaseController {
         if (!StringUtils.isBlank(HaloConst.OPTIONS.get("index_posts"))) {
             size = Integer.parseInt(HaloConst.OPTIONS.get("index_posts"));
         }
-        Pageable pageable = new PageRequest(page - 1, size, sort);
+        Pageable pageable = PageRequest.of(page - 1, size, sort);
         Page<Post> posts = postService.findPostsByTags(tag, pageable);
         model.addAttribute("posts", posts);
         model.addAttribute("tag", tag);


### PR DESCRIPTION
具体表现为: 新建文章时, "永久链接"以.html或者.htm结尾, 可以保存, 查看时ControllerNPE