### PR TITLE
修复字段长度设置错误问题导致使用mysql数据库初始化报错的问题

### DIFF
--- a/src/main/java/cc/ryanc/halo/model/domain/Options.java
+++ b/src/main/java/cc/ryanc/halo/model/domain/Options.java
@@ -2,10 +2,7 @@ package cc.ryanc.halo.model.domain;
 
 import lombok.Data;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.io.Serializable;
 
 /**
@@ -27,6 +24,7 @@ public class Options implements Serializable {
      * 设置项名称
      */
     @Id
+    @Column(length = 127)
     private String optionName;
 
     /**


### PR DESCRIPTION
修复字段长度设置错误问题导致使用mysql数据库初始化报错的问题