### PR TITLE
添加jaxb-api依赖

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,12 @@
 
 	<dependencies>
 
+		<!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+		<dependency>
+    			<groupId>javax.xml.bind</groupId>
+    			<artifactId>jaxb-api</artifactId>
+    			<version>2.3.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>


### PR DESCRIPTION
修复了在Ubuntu18.04 openjdk-11中启动失败问题